### PR TITLE
Move piece list out of game state, it doesn't need to be a part of the

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Vividmind is a work-in-progress chess engine written in C++. It adheres to the U
 ## Search
 * Alpha-Beta
 * Iterative Deepening
-* Null Move Pruning
 * Quiescence Search
 
 ## Evaluation

--- a/include/board.hpp
+++ b/include/board.hpp
@@ -20,13 +20,10 @@ struct GameState {
     Color player_to_move;
     std::optional<int> en_passant_square;
     std::array<Castling, 2> castling_rights;
-    std::array<std::vector<Piece>, 2> pieces;
     std::array<int, 2> material;
     std::array<int, 2> psqt;
     std::optional<Piece> captured_piece;
     Move next_move;
-
-    bool operator==(GameState other) const;
 };
 
 class Board {
@@ -35,6 +32,7 @@ class Board {
         const static std::array<int, 64> mailbox64;
 
         std::array<Square, 64> squares;
+        std::array<std::vector<Piece>, 2> pieces;
         GameState game_state;
         std::vector<GameState> history;
 
@@ -43,12 +41,12 @@ class Board {
         static Board get_starting_position();
         static Board get_position_from_fen(std::string fen);
 
+        bool operator==(const Board& board) const;
+
         void show() const;
         void switch_player_to_move();
         void make(const Move& move);
         void undo();
-        void make_null_move();
-        void undo_null_move();
         int get_king_square(Color color) const;
 
     private:

--- a/include/engine/engine.hpp
+++ b/include/engine/engine.hpp
@@ -54,7 +54,7 @@ class Engine {
         static const int ALPHA_INITIAL_VALUE = -CHECKMATE;
 
         void iterative_deepening_search(int search_depth, int allocated_time_ms);
-        int search(int depth, int alpha, int beta, int time_left, std::vector<Move>& principal_variation, bool last_was_nullmove);
+        int search(int depth, int alpha, int beta, int time_left, std::vector<Move>& principal_variation);
         int search_captures(int alpha, int beta, int time_left);
         int evaluate();
         void show_uci_info() const;

--- a/src/game_over_detector.cpp
+++ b/src/game_over_detector.cpp
@@ -24,7 +24,7 @@ bool GameOverDetector::is_checkmate(std::vector<Move>& legal_moves) const {
 }
 
 bool GameOverDetector::is_insufficient_material() const {
-    for (const std::vector<Piece>& pieces : board.game_state.pieces) {
+    for (const std::vector<Piece>& pieces : board.pieces) {
         for (Piece piece : pieces) {
             if (piece.piece_type == PAWN || piece.piece_type == ROOK || piece.piece_type == QUEEN) {
                 return false;
@@ -35,10 +35,12 @@ bool GameOverDetector::is_insufficient_material() const {
 }
 
 bool GameOverDetector::is_threefold_repetition() const {
+    Board old_board = board;
     int repetitions = 1;
-    for (int i = board.history.size() - 1; i >= 0; i--) {
-        const GameState& old_state = board.history.at(i);
-        if (old_state == board.game_state) {
+    const int history_size = board.history.size();
+    for (int i = 0; i < history_size - 1; i++) {
+        old_board.undo();
+        if (board == old_board) {
             repetitions++;  
         }         
         if (repetitions == 3) {

--- a/src/move_generator.cpp
+++ b/src/move_generator.cpp
@@ -16,7 +16,7 @@ MoveGenerator::MoveGenerator(Board& board)
 
 std::vector<Move> MoveGenerator::get_pseudo_legal_moves(MoveType move_type) const {
     std::vector<Move> moves;
-    for (Piece piece : board.game_state.pieces[board.game_state.player_to_move]) {
+    for (Piece piece : board.pieces[board.game_state.player_to_move]) {
         std::vector<Move> piece_moves = get_pseudo_legal_moves(piece, move_type);
         moves.insert(std::end(moves), std::begin(piece_moves), std::end(piece_moves));
     } 


### PR DESCRIPTION
history, and it severly slowed down making moves since all the pieces had to be copied in to the history. Also removed null move pruning since it was a bit annoying, I might add it back later.

closes #106 